### PR TITLE
Ignore protocol on links

### DIFF
--- a/routing-simulator.html
+++ b/routing-simulator.html
@@ -3,8 +3,8 @@
 <head>
     <title>Routing Sim</title>
 </head>
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-<script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.0/js/bootstrap.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.0/js/bootstrap.min.js"></script>
 <script type="text/javascript">
 $(function() {
     var nodeMarginFac = 0.1,
@@ -326,7 +326,7 @@ $(function() {
 });
 </script>
 
-<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.0/css/bootstrap-combined.min.css" rel="stylesheet">
+<link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.0/css/bootstrap-combined.min.css" rel="stylesheet">
 
 <style type="text/css">
 #sim {


### PR DESCRIPTION
This page doesn't work on HTTPS, which is also supported by Github Pages. I use the "HTTPS Everywhere" browser extension, and navigating to this page didn't work because the non-secure links aren't being followed. I removed the protocol from those links, so the links will default to the protocol used when navigating to this page (either HTTP or HTTPS).